### PR TITLE
[READY] 404 error page

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -169,7 +169,8 @@ helpers do
     html = ""
     (langs - [I18n.locale]).each do |lang|
       img = image_tag("flags/#{lang}.gif", alt: flag_titles[lang])
-      url = current_page.locale_root_path || "/"
+      locale_root_path = current_page.locale_root_path
+      url = locale_root_path && locale_root_path != "/error.html" ? locale_root_path : "/"
       html << locale_link_to(img, url, title: flag_titles[lang], locale: lang)
     end
     html

--- a/source/javascripts/_ebook-form.js
+++ b/source/javascripts/_ebook-form.js
@@ -2,7 +2,7 @@ var Defacto = Defacto || {};
 
 Defacto.ebookForm = {
   submit: function (event) {
-    var ebookUrl = Defacto.downloads.ebook[I18n.locale];
+    var ebookUrl = Defacto.downloads.ebook[Defacto.I18n.locale];
     var $form = $(this);
     var $submit = $form.find('button[type=submit]');
     var $formField = $form.find('input[name=form]');

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -38,7 +38,10 @@
     <% end %>
 
     <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script> window.I18n = { locale: "<%= I18n.locale %>" }; </script>
+    <script>
+    var Defacto = Defacto || {};
+    Defacto.I18n = { locale: "<%= I18n.locale %>" };
+    </script>
     <%= javascript_include_tag "all" %>
 
     <script>

--- a/source/localizable/error.html.erb
+++ b/source/localizable/error.html.erb
@@ -2,6 +2,26 @@
 directory_index: false
 ---
 
+<% if is_default_locale?
+  error_pages = {}
+  (langs - [I18n.locale]).each do |lang|
+    error_pages[lang] = locale_url_for(current_path, locale: lang)
+  end
+  %>
+
+  <script>
+  // Redirect to localized 404 when needed
+  try {
+    var error_pages = JSON.parse('<%= error_pages.to_json.html_safe %>');
+    var lang = window.location.pathname.replace(/^\//, '').split('/')[0];
+    // if (error_pages[lang]) {
+    //   window.location.replace(error_pages[lang]);
+    // }
+    error_pages[lang] && window.location.replace(error_pages[lang]);
+  } catch (error) {}
+  </script>
+<% end %>
+
 <section class="gray">
   <div class="row">
     <%= image_tag "warning.gif", class: "header-icon" %>

--- a/source/localizable/error.html.erb
+++ b/source/localizable/error.html.erb
@@ -3,20 +3,16 @@ directory_index: false
 ---
 
 <% if is_default_locale?
+  # Redirect to localized error page when needed
   error_pages = {}
   (langs - [I18n.locale]).each do |lang|
     error_pages[lang] = locale_url_for(current_path, locale: lang)
   end
   %>
-
   <script>
-  // Redirect to localized 404 when needed
   try {
     var error_pages = JSON.parse('<%= error_pages.to_json.html_safe %>');
     var lang = window.location.pathname.replace(/^\//, '').split('/')[0];
-    // if (error_pages[lang]) {
-    //   window.location.replace(error_pages[lang]);
-    // }
     error_pages[lang] && window.location.replace(error_pages[lang]);
   } catch (error) {}
   </script>


### PR DESCRIPTION
- [x] javascript redirect to localized error pages. Divshot uses [superstatic](https://github.com/divshot/superstatic) which only except a single `error_page`. Haven't found a better solution..
- [x] language switcher from error pages link to `/` to prevent conflicts.
- [x] store i18n in javascript under `Defacto.i18n` namespace.