### PR TITLE
Correct links to German learningspaces website

### DIFF
--- a/source/localizable/_product_highlights.erb
+++ b/source/localizable/_product_highlights.erb
@@ -23,7 +23,12 @@
         </p>
       </div>
       <%= locale_link_to t("actions.read_more"), "/learningspaces.html", class: "button white outline" %>
-      <%= link_to t("actions.visit_website"), "http://www.learningspaces.nl", target: "_blank", class: "button white outline" %>
+      <% if I18n.locale == :nl %>
+       <%= link_to t("actions.visit_website"), "http://www.learningspaces.nl", target: "_blank", class: "button white outline" %>
+      <% end %>
+      <% if I18n.locale == :de %>
+       <%= link_to t("actions.visit_website"), "http://www.learningspaces.de", target: "_blank", class: "button white outline" %>
+      <% end %>
     </div>
   </div>
 

--- a/source/localizable/learningspaces.html.erb
+++ b/source/localizable/learningspaces.html.erb
@@ -8,8 +8,17 @@ title: LearningSpaces
       <h1><%= image_tag "logos/learningspaces-white.png", alt: "LearningSpaces" %></h1>
       <%= markitdown t("learningspaces.hero.text_md") %>
     </div>
-    <%= link_to t("actions.try_for_free"), "http://public.learningspaces.nl/accounts/new", class: "button" %>
-    <%= link_to t("actions.visit_website"), "http://learningspaces.nl", target: "_blank", class: "button white outline" %>
+
+    <% if I18n.locale == :nl %>
+       <%= link_to t("actions.try_for_free"), "http://public.learningspaces.nl/accounts/new", class: "button" %>
+       <%= link_to t("actions.visit_website"), "http://learningspaces.nl", target: "_blank", class: "button white outline" %>
+      <% end %>
+      <% if I18n.locale == :de %>
+       <%= link_to t("actions.try_for_free"), "https://public.learningspaces.de/accounts/new", class: "button" %>
+       <%= link_to t("actions.visit_website"), "http://learningspaces.de", target: "_blank", class: "button white outline" %>
+      <% end %>
+
+    
   </div>
 </div>
 


### PR DESCRIPTION
On homepage /de and /de/learningspaces correct links. Issue #117 

@dkhgh @sn3p 