### PR TITLE
[abandoned] Ronald/content and layout improvements

### DIFF
--- a/data/testimonials.yml
+++ b/data/testimonials.yml
@@ -71,7 +71,6 @@
 - name: Peter van Overbruggen
   company: "Opleidingsadviseur, ZuidZorg"
   avatar: testimonials/peter_van_overbruggen.jpg
-  featured: true
   quote: >
     <p>Het project met Defacto betrof de invoering van CAPP11 in onze organisatie voor alle drie de onderdelen
     (opleiden, ontwikkelen en kwaliteit). Het contact met de mensen van Defacto verliep prima. Zij zijn samenwerkingsgericht,

--- a/data/testimonials_de.yml
+++ b/data/testimonials_de.yml
@@ -72,7 +72,6 @@
 - name: Peter van Overbruggen
   company: "Fortbildungsbeauftragter, ZuidZorg"
   avatar: testimonials/peter_van_overbruggen.jpg
-  featured: true
   quote: >
     <p>Das Projekt mit Defacto ging um die Einführung von CAPP11 in unserer Organisation mit allen drei Teilen
     (Bilden, Entwickeln, Qualitätspass). Der Kontakt mit den Leuten von Defacto verlief super. Sie richten sich auf Zusammenarbeit,

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -181,7 +181,8 @@ de:
     name: LearningSpaces
     start_now: "Starte durch mit LearningSpaces"
   products:
-    title: "Produkte auf die wir stolz sind."
+    title: "Produkte auf die wir stolz sind"
+    subtitle: "Ein vollständiges Bild des Lernens, der Entwicklung und Qualifizierung"
   references:
     title: "Einige Referenzen"
   services:

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -204,6 +204,7 @@ de:
     title: "Dienstleistungen auf die wir stolz sind."
   testimonials:
     title: "Was unsere Kunden sagen"
+    more_testimonials: "Mehr Kundenreferenzen"
   thanks:
     heading: "Vielen Dank."
     message: "Wir melden uns so schnell wie möglich bei Ihnen."

--- a/locales/nl.yml
+++ b/locales/nl.yml
@@ -191,6 +191,7 @@ nl:
     title: "Diensten waar we trots op zijn."
   testimonials:
     title: "Wat anderen zeggen"
+    more_testimonials: "Meer testimonials"
   thanks:
     heading: Bedankt!
     message: Je hoort zo snel mogelijk van ons.

--- a/locales/nl.yml
+++ b/locales/nl.yml
@@ -115,7 +115,7 @@ nl:
       develop:
         keywords:
           - "360° Feedback"
-          - Compententies
+          - Competenties
           - Jaargesprekken
         text_html: "Geef medewerkers efficiënte tools voor hun ontwikkelprocessen en een overzichtelijk persoonlijk portfolio."
         title: Ontwikkelen
@@ -154,7 +154,7 @@ nl:
     desc: "Garandeer kwaliteit binnen uw organisatie door te werken aan bevoegdheden en bekwaamheden van uw medewerkers. Maak uw organisatie toekomstbestendig met het %{link}."
     hero:
       formkeep_title: "Kwaliteitspaspoort: meer informatie"
-      text_md: "Aantoonbaar vakbekwaam met CAPP Kwaliteitspaspoort"
+      text_md: "Iedere medewerker aantoonbaar vakbekwaam met het CAPP Kwaliteitspaspoort"
       title: Kwaliteitspaspoort
     logo: logos/kwaliteitspaspoort-white.png
     name: Kwaliteitspaspoort

--- a/locales/nl.yml
+++ b/locales/nl.yml
@@ -118,7 +118,7 @@ nl:
           - Competenties
           - Jaargesprekken
         text_html: "Geef medewerkers efficiënte tools voor hun ontwikkelprocessen en een overzichtelijk persoonlijk portfolio."
-        title: Ontwikkelen
+        title: CAPP Ontwikkelen
       headline: "Defacto helpt organisaties bij het ontwikkelen en certificeren van hun medewerkers"
       informal:
         keywords:
@@ -133,14 +133,14 @@ nl:
           - Leermanagament
           - "E-Learning / ELO"
         text_html: "De stille, krachtige motor van uw academie. Stroomlijn processen en bespaar tijd. Creëer inzicht met %{link} Leren."
-        title: Leren
+        title: CAPP Leren
       quality:
         keywords:
           - Verplichte opleiding en praktijkervaring vastleggen
           - Bewaken certificering
           - Kwaliteitsmonitor voor accreditatie van NIAZ, ISO, WFT, Wet BIO, JSI, etc.
         text_html: "Real-time inzicht in vakbevoegdheid van uzelf, uw team en uw organisatie. Voldoe permanent en zichtbaar aan de (formele) kwaliteitseisen."
-        title: Kwaliteitspaspoort
+        title: CAPP Kwaliteitspaspoort
   hosting:
     heading: "Hosting & Security"
   implementaties:

--- a/locales/nl.yml
+++ b/locales/nl.yml
@@ -168,7 +168,8 @@ nl:
     name: LearningSpaces
     start_now: "Begin nu met LearningSpaces"
   products:
-    title: "Producten waar we trots op zijn."
+    title: "Producten waar we trots op zijn"
+    subtitle: "Een compleet beeld van leren, ontwikkelen en kwalificeren"
   references:
     title: "Enkele referenties"
   services:

--- a/locales/nl.yml
+++ b/locales/nl.yml
@@ -163,7 +163,7 @@ nl:
       heading_md: "Vandaag nog beginnen met een gratis trial?"
     desc: "%{link} is een laagdrempelig social-learning platform dat leren en kennisdeling stimuleert."
     hero:
-      text_md: "__LearningSpaces__ is een laagdrempelig social-learning platform dat leren en kennisdeling stimuleert."
+      text_md: "LearningSpaces is een laagdrempelig social-learning platform dat leren en kennisdeling stimuleert."
     logo: logos/learningspaces-white.png
     name: LearningSpaces
     start_now: "Begin nu met LearningSpaces"

--- a/source/localizable/_product_highlights.erb
+++ b/source/localizable/_product_highlights.erb
@@ -3,7 +3,7 @@
   <div class="col col-capp">
     <div class="inner">
       <div class="headline">
-        <h2><%= locale_link_to "CAPP", "/capp.html" %></h2>
+        <h2><%= locale_link_to "CAPP LMS", "/capp.html" %></h2>
         <p class="sub-headline">
           <%= t("home.highlights.capp.text_html", link: locale_link_to("CAPP LMS Software", "/capp.html")) %>
         </p>

--- a/source/localizable/capp/_capp.nl.md.erb
+++ b/source/localizable/capp/_capp.nl.md.erb
@@ -3,32 +3,32 @@
 
     <div class="headline">
       <h2>
-        De basis van elke moderne academie of opleidingsafdeling. Uitnodigend, betrouwbaar en super eenvoudig.
+        De basis van elke moderne academie of opleidingsafdeling. Uitnodigend, betrouwbaar en eenvoudig.
       </h2>
     </div>
 
     <div class="col">
       <%= image_tag "icons/leren-blue.png", alt: "Leren" %>
-      <h3>Leren</h3>
-      <p>Bied uw deelnemers een unieke leerbeleving, met een rijk mix aan leervormen zowel klassikaal als via E-Learning en een eenvoudige leerproces.</p>
+      <h3>CAPP Leren</h3>
+      <p>Biedt uw deelnemers een unieke leerbeleving met een rijke mix aan leervormen (zowel klassikaal als via e-learning) en een eenvoudig leerproces.</p>
       <hr>
       <ul class="checklist">
         <li>Opleidingscatalogus</li>
-        <li>Blended learning </li>
-        <li>E-Learning omgeving </li>
-        <li>Digitaal Leerportaal </li>
+        <li>Blended learning</li>
+        <li>E-learning omgeving</li>
+        <li>Digitaal leerportaal</li>
         <li>Cursusadministratie</li>
       </ul>
     </div>
 
     <div class="col">
       <%= image_tag "icons/ontwikkelen-blue.png", alt: "Ontwikkelen" %>
-      <h3>Ontwikkelen</h3>
-      <p>Speciaal om uw medewerkers te helpen bij hun persoonlijke en professionele ontwikkeling biedt CAPP Ontwikkelen enkele bijzondere oplossingen:</p>
+      <h3>CAPP Ontwikkelen</h3>
+      <p>Speciaal om uw medewerkers te helpen bij hun professionele en persoonlijke ontwikkeling biedt CAPP Ontwikkelen enkele bijzondere oplossingen:</p>
       <hr>
       <ul class="checklist">
-        <li>E-Portfolio</li>
-        <li>Compententiemanagement</li>
+        <li>E-portfolio</li>
+        <li>Competentiemanagement</li>
         <li>Jaargesprekken</li>
       </ul>
     </div>
@@ -36,9 +36,9 @@
     <div class="col">
       <% locale_link_to "/kwaliteitspaspoort.html" do %>
         <%= image_tag "icons/borging-blue.png", alt: "Borging" %>
-        <h3>Kwaliteitspaspoort</h3>
+        <h3>CAPP Kwaliteitspaspoort</h3>
       <% end %>
-      <p>Een persoonsgebonden profiel waarin de bekwaamheden en bevoegdheden in één keer inzichtelijk zijn voor werknemer, werkgever en toezichthoudende instanties.</p>
+      <p>Een persoonsgebonden profiel waarin de bekwaamheden en bevoegdheden in een keer inzichtelijk zijn voor werknemer, werkgever en toezichthoudende instanties.</p>
       <hr>
       <ul class="checklist">
         <li>Kwaliteitsmonitor altijd actueel</li>

--- a/source/localizable/diensten.html.erb
+++ b/source/localizable/diensten.html.erb
@@ -7,7 +7,7 @@ title:
 
 <section class="gray">
   <div class="row">
-    <h2><%= t("services.title") %></h2>
+    <h1><%= t("services.title") %></h1>
     <br>
 
     <ul class="solitions-list">

--- a/source/localizable/elearning/_elearning.nl.md.erb
+++ b/source/localizable/elearning/_elearning.nl.md.erb
@@ -19,6 +19,3 @@ Met de **[E-learning Starterkit](elearning-starterkit.html)** ontwikkel je betaa
 - Volledige controle over het lesmateriaal
 - Korte doorlooptijd
 - Direct en laagdrempelig aan de slag
-
-### Onafhankelijk advies
-Of we nu samenwerken, ontwikkelen of ondersteunen, Defacto streeft er altijd naar het beste voor jouw organisatie neer te zetten. Wij vinden niet graag het wiel opnieuw uit, omdat wij ons graag richten op nieuwe dingen. Als er e-learning bestaat dat geschikt is voor jouw organisatie dan gaan we graag om tafel om samen de voordelen en nadelen tegen elkaar af te wegen. Er is immers al een groot en goed aanbod in de wereld!

--- a/source/localizable/elearning/_elearning.nl.md.erb
+++ b/source/localizable/elearning/_elearning.nl.md.erb
@@ -1,25 +1,24 @@
-Defacto is een ervaren E-Learning partner. Van de allereerste webinars nog in de jaren ‘90 tot aan de veelvoudige mogelijkheden van vandaag. Dat betekent voor jouw organisatie dat we naadloos kunnen aansluiten bij de vraag en de behoefte. Of het nou gaat om een eenvoudige module of een hoogwaardige mediaproductie. Met Defacto als zowel onderwijskundig en technisch onderlegde partner, wordt de toepassing van E-Learning in jouw organisatie onherroepelijk een succes.
+Defacto is een zeer ervaren e-learning partner. Van de allereerste webinars, nog in de jaren ‘90, tot aan de veelvoudige mogelijkheden van vandaag. En of het nu gaat om een eenvoudige module of een hoogwaardige mediaproductie, we sluiten naadloos aan bij jouw vraag en behoefte. Met Defacto als onderwijskundig en technisch onderlegde partner wordt de toepassing van e-learning in jouw organisatie onherroepelijk een succes.
 
 <iframe src="//player.vimeo.com/video/86035039" width="500" height="281" frameborder="0" allowfullscreen></iframe>
 
 ### Cocreatie
-Co-creatie is onze favoriete vorm van samenwerking. Bij Defacto geloven wij in de kracht van jouw organisatie. Door gezamenlijk met jou E-Learning scholing te ontwikkelen bundelen we de krachten: Inhoud en kennis van jullie, technische en onderwijskundige degelijkheid van Defacto. Zo maken we modules waar je blij van wordt.
+Co-creatie is onze favoriete vorm van samenwerking. Bij Defacto geloven we in de kracht van jouw organisatie. Door gezamenlijk met jou e-learning scholing te ontwikkelen bundelen we de krachten: inhoud en kennis van jullie, technische en onderwijskundige degelijkheid van Defacto. Zo maken we modules waar je blij van wordt.
 
-### Ontwikkelen van modules
-Natuurlijk kunnen wij het ontwikkelen van E-Learning ook op ons nemen. Onze onderwijskundigen gaan dan aan de slag met de technische mensen en in een mum van tijd kunnen wij de gevraagde module leveren. Snel en adequaat, zo staan we bij onze klanten bekend.
+### Ontwikkelen van e-learning modules
+Uiteraard kunnen we het ontwikkelen van e-learning ook op ons nemen. Onze onderwijskundigen gaan aan de slag met de technische mensen en in een mum van tijd kunnen wij de gevraagde module(s) leveren. Snel en adequaat, zo staan we bij onze klanten bekend.
 
-> E-Learningcontent van Defacto is SCORM-compliant en dus vrij te gebruiken in bijna alle leeromgevingen.
+> E-learning content van Defacto is SCORM-compliant en dus vrij te gebruiken in bijna alle leeromgevingen.
 
 ### E-Learning Starterkit
-Met de **[E-learning Starterkit](elearning-starterkit.html)** ontwikkel je betaalbaar, snel en eenvoudig E-learning modules. Maak E-Learning gericht op specifieke vakkennis, gedragscodes of zelfs digitale toetsen. De Starterkit bestaat uit een totaalpakket van hardware, software en consultancy.
+Met de **[E-learning Starterkit](elearning-starterkit.html)** ontwikkel je betaalbaar, snel en eenvoudig e-learning modules. Maak e-learning gericht op specifieke vakkennis, gedragscodes of zelfs digitale toetsen. De Starterkit bestaat uit een totaalpakket van hardware, software en consultancy.
 
-**De voordelen van de Starterkit op een rij:**
+### De voordelen van de E-Learning Starterkit:
 
-- Eenmalige investering
-- Geen verborgen kosten
+- Eenmalige investering, dus geen verborgen kosten
 - Volledige controle over het lesmateriaal
 - Korte doorlooptijd
 - Direct en laagdrempelig aan de slag
 
 ### Onafhankelijk advies
-Of wij nou samenwerken, ontwikkelen of ondersteunen. Defacto streeft ernaar het beste voor jouw organisatie neer te zetten. Wij vinden niet graag het wiel opnieuw uit, omdat wij ons graag richten op nieuwe dingen. Als er E-Learning bestaat dat geschikt is voor jouw organisatie, gaan wij graag om tafel om samen met jou de voordelen en nadelen tegen elkaar af te wegen. Er is immers een groot en goed aanbod al in de wereld!
+Of we nu samenwerken, ontwikkelen of ondersteunen, Defacto streeft er altijd naar het beste voor jouw organisatie neer te zetten. Wij vinden niet graag het wiel opnieuw uit, omdat wij ons graag richten op nieuwe dingen. Als er e-learning bestaat dat geschikt is voor jouw organisatie dan gaan we graag om tafel om samen de voordelen en nadelen tegen elkaar af te wegen. Er is immers al een groot en goed aanbod in de wereld!

--- a/source/localizable/hosting/_hosting.nl.md.erb
+++ b/source/localizable/hosting/_hosting.nl.md.erb
@@ -1,17 +1,17 @@
-## Hosting
+Defacto biedt de mogelijkheid om CAPP gehost aan te bieden. Zo belast u uw systeembeheer amper en worden updates door Defacto voor u geïnstalleerd en bijgewerkt. Wanneer CAPP gehost wordt aangeboden is het voor uw medewerkers mogelijk om vanuit uw website, zonder apart te moeten inloggen, in CAPP terecht te kunnen. 
 
-Defacto biedt u de mogelijkheid om CAPP gehost aan te bieden. Op deze manier belast u uw systeembeheer amper, worden updates door Defacto voor u geïnstalleerd en bijgewerkt. Ook indien CAPP gehost wordt aangeboden, is het voor uw medewerkers vanuit uw website zonder apart in te loggen, rechtstreeks in CAPP terecht kunnen.
+### Veiligheid boven alles
 
-De gegevens van uw medewerkers vanuit uw HR systeem worden – indien gewenst - elke nacht in CAPP ingelezen. Daarbij maakt Defacto gebruik van SSH File Transfer Protocol (sFTP). Tijdens de verzending van de data wordt deze (in tegenstelling tot FTP) versleuteld en is daarmee zeer veilig.
+De gegevens van uw medewerkers vanuit uw HR systeem worden indien gewenst elke nacht in CAPP ingelezen. Daarbij maken we gebruik van SSH File Transfer Protocol (sFTP). Tijdens de verzending van de data wordt deze versleuteld en is daarmee zeer veilig.
 
----
+### Voordelen 
 
-- Onze software is volledig web based en is altijd en overal bereikbaar.
-- CAPP kan als SAAS-service en lokaal gehost afgenomen worden.
+- Onze software is volledig web based en is altijd en overal bereikbaar
+- CAPP kan als SaaS-service en lokaal gehost afgenomen worden
 - CAPP biedt Standaard Single Sign On (SSO integratie)
-- Als old-school softwarebedrijf kennen wij alle ins en outs van de techniek en zijn wij een volwaardige partner voor uw ICT-organisatie. ICT gerelateerde problemen zult u met ons en onze software niet hebben.
-- CAPP voldoet aan de ICT-Beveiligingsrichtlijnen voor web applicaties - Deel 1, Nationaal Cyber Security Centrum, Ministerie van Veiligheid en Justitie.
-- CAPP kent een standaard HR-Importer die koppelingen met alle bekende nationale en internationale HR-systemen eenvoudig kan realiseren.
-- CAPP kent talloze koppelingen met (kwaliteit)registers, toetsingssystemen, e-learning leveranciers.
-- CAPP is een open systeem waarin u e-learning materiaal van alle bekende e-learning leveranciers kunt afspelen.
-- CAPP is in zowel Nederlands, Engels als Duits te verkrijgen.
+- Als old-school softwarebedrijf kennen wij alle ins en outs van de techniek en zijn wij een volwaardige partner voor uw ICT-organisatie. ICT gerelateerde problemen zult u met ons en onze software niet hebben
+- CAPP voldoet aan de ICT-Beveiligingsrichtlijnen voor web applicaties - Deel 1, Nationaal Cyber Security Centrum, Ministerie van Veiligheid en Justitie
+- CAPP kent een standaard HR importer die koppelingen met alle bekende nationale en internationale HR-systemen eenvoudig kan realiseren
+- CAPP kent talloze koppelingen met (kwaliteit)registers, toetsingssystemen, e-learning leveranciers
+- CAPP is een open systeem waarin u e-learning materiaal van alle bekende e-learning leveranciers kunt afspelen
+- CAPP is zowel in het Nederlands, Engels als Duits verkrijgbaar

--- a/source/localizable/implementaties/_implementaties.nl.md.erb
+++ b/source/localizable/implementaties/_implementaties.nl.md.erb
@@ -1,16 +1,23 @@
-De ervaring heeft ons geleerd dat één van de belangrijkste aspecten van een succesvolle digitale leerstrategie direct gekoppeld is aan het implementatietraject. Daarom heeft Defacto een eigen implementatiemethodiek ontwikkeld waarin onze projectleider en consultants samen met uw management team de strategie en uitvoering waarborgen.Een gedegen implementatieproject is een bepalende voorwaarde voor het succesvol lanceren / in gebruik nemen van onze software. Niet dat het allemaal zo ingewikkeld is, maar als je gaat verhuizen moet je ook je woning inrichten. In ons geval moeten we samen met u de software inrichten. Niet ingewikkeld en wij leiden u soepel door dit proces heen.
+De ervaring heeft ons geleerd dat een van de belangrijkste aspecten van een succesvolle digitale leerstrategie direct gekoppeld is aan de implementatie ervan. Daarom heeft Defacto een eigen implementatiemethodiek ontwikkeld waarbij onze projectleider en consultants samen met uw managementteam de strategie en uitvoering waarborgen. Niet dat het allemaal zo ingewikkeld is, maar als je gaat verhuizen moet je ook je woning inrichten. In ons geval richten we samen met u de software in. Wij leiden u soepel door dit proces heen.
 
-- De afstemming met uw ICT-afdeling nemen wij voor onze rekening.
-- We zorgen – indien gewenst - voor de koppeling met uw HR-systeem zodat u altijd over de meest recente gegevens beschikt.
-- We maken samen met u een digitale opleidingscatalogus.
-- We leiden de gebruikers op.
-- Ook helpen wij u bij de inrichting van jaargesprekken, kwaliteitspaspoort en wat dies meer zij.
-- Desgewenst helpen wij u bij de introductie van het systeem in uw organisatie.
+### We zorgen voor:
 
-Bij grotere organisaties adviseren wij de oprichting van een Stuurgroep waarin uw en ons management vertegenwoordigd is, voor het creëren van voldoende draagvlak.
+- de afstemming met uw ICT-afdeling;
+- de koppeling met uw HR-systeem zodat u altijd over de meest recente gegevens beschikt (indien wenselijk);
+- het samen met u maken van een digitale opleidingscatalogus;
+- het opleiden van gebruikers.
+
+### We helpen bij: 
+
+- de inrichting van jaargesprekken, het **[Kwaliteitspaspoort](/kwaliteitspaspoort)** en wat dies meer zij;
+- de introductie van het systeem in uw organisatie.
+
+### Draagvlak en uitvoering 
+
+Bij grotere organisaties adviseren we om een Stuurgroep op te richten, waarin uw en ons management vertegenwoordigd zijn, voor het creëren van voldoende draagvlak.
 
 Het uitvoerende werk vindt uiteraard plaats in de projectgroep, waarin uw en onze projectleider aan de hand van een duidelijk projectplan zorgen voor een feilloze implementatie.
 
 ### Onafhankelijk advies
 
-Of wij nou samenwerken, ontwikkelen of ondersteunen. Defacto streeft ernaar het beste voor jouw organisatie neer te zetten. Wij vinden niet graag het wiel opnieuw uit, omdat wij ons graag richten op nieuwe dingen. Als er E-Learning bestaat dat geschikt is voor jouw organisatie, gaan wij graag om tafel om samen met jou de voordelen en nadelen tegen elkaar af te wegen. Er is immers een groot en goed aanbod al in de wereld!
+Of we nu samenwerken, ontwikkelen of ondersteunen, Defacto streeft er altijd naar het beste voor jouw organisatie neer te zetten. Wij vinden niet graag het wiel opnieuw uit, omdat wij ons graag richten op nieuwe dingen. Als er e-learning bestaat dat geschikt is voor jouw organisatie dan gaan we graag om tafel om samen de voordelen en nadelen tegen elkaar af te wegen. Er is immers al een groot en goed aanbod in de wereld!

--- a/source/localizable/index.html.erb
+++ b/source/localizable/index.html.erb
@@ -22,18 +22,21 @@ sitemap_priority: 1
 
 <%= partial "product_highlights" %>
 
-<section class="testimonials cols">
+<section class="testimonials">
   <div class="headline">
     <h2><%= t("testimonials.title") %></h2>
   </div>
   <div class="row">
 
     <%= partial "testimonials", locals: {
-      count: 2,
+      count: 1,
       featured: true,
       summary: true
     } %>
 
+  </div>
+  <div class="row">
+    <%= nav_link_to t("testimonials.more_testimonials"), "/testimonials.html", class: "button blue outline" %>
   </div>
 </section>
 

--- a/source/localizable/index.html.erb
+++ b/source/localizable/index.html.erb
@@ -37,5 +37,5 @@ sitemap_priority: 1
   </div>
 </section>
 
-<%= partial "blog/featured" %>
+<%#= partial "blog/featured" %>
 <%= partial "clients" %>

--- a/source/localizable/koppelingen/_koppelingen.nl.md.erb
+++ b/source/localizable/koppelingen/_koppelingen.nl.md.erb
@@ -1,18 +1,18 @@
-Defacto maakt gebruik van een standaard HR Importer. Via deze HR Importer wordt CAPP gevoed vanuit bronsystemen als Beaufort, People Soft, SAP en vele andere HR systemen. Defacto onderhoudt haar HR Importer als een product waardoor u standaard altijd de juiste versie bij uw CAPP versie zult gebruiken.
+Defacto maakt gebruik van een standaard HR importer. Via de importer wordt CAPP gevoed uit bronsystemen als Beaufort, People Soft, SAP en vele andere HR systemen. Defacto onderhoudt haar HR importer als een product waardoor u standaard altijd de juiste versie bij uw CAPP versie zult gebruiken.
 Daarnaast heeft Defacto integratie gerealiseerd met meerdere systemen.
 
 ### Verpleegkundigen &amp; Verzorgend Nederland (V&amp;VN)
 
-Met V&amp;VN wordt de geaccrediteerde E-learning die uw medewerkers binnen CAPP volgen automatisch vastgelegd binnen PE Online. Hiermee hoeft u of uw medewerkers geen dubbele registratie te voeren.
+Met V&amp;VN wordt de geaccrediteerde e-learning die uw medewerkers binnen CAPP volgen automatisch vastgelegd binnen PE Online. Hiermee hoeven u of uw medewerkers geen dubbele registratie te voeren.
 
 ### Leerstation Zorg
 
-Via onze koppeling met Leerstation Zorg is het mogelijk uw medewerkers na het volgen van E-learning binnen CAPP vervolgens direct getoetst kunnen worden binnen Leerstation Zorg. Natuurlijk worden de resultaten van de toetsing automatisch binnen CAPP vastgelegd. Ook hiermee vermijdt u weer dubbele registratie.
+Via onze koppeling met Leerstation Zorg is het mogelijk dat uw medewerkers na het volgen van e-learning binnen CAPP direct getoetst worden in Leerstation Zorg. Uiteraard worden de resultaten van de toetsing volledig automatisch in CAPP vastgelegd. Ook hiermee vermijdt u dubbel registreren.
 
 ### Learning Tools Interoperability (LTI)
 
-Alle E-learning content die een LTI-koppeling ondersteunt, en die ergens anders gehost wordt, kan nu in CAPP getoond worden. Hierdoor bent u niet meer gebonden aan één leverancier en beslist u zelf waar u de E-learning content vandaan haalt. Zo kan op deze manier bijvoorbeeld de content van Profportaal Zorg naadloos worden afgespeeld in CAPP en worden de gegenereerde resultaten in de CAPP-omgeving getoond.
+Alle e-learning content die een LTI-koppeling ondersteunt en ergens anders gehost wordt kan in CAPP getoond worden. Hierdoor bent u niet  gebonden aan een leverancier en beslist u zelf waar u e-learning content vandaan haalt. Zo kan de content van Profportaal Zorg naadloos worden afgespeeld in CAPP en worden de resultaten in de CAPP-omgeving getoond.
 
 ### Medisch Onderwijs (MO)
 
-Medisch Onderwijs.nl is bedoeld voor de distributie van ‘medical computer based training’. In Medisch Onderwijs werkt een groot aantal universiteiten en hoge scholen samen. Vanuit CAPP kunnen ook modules die in Medisch Onderwijs zijn vastgelegd, direct worden opgestart. Natuurlijk worden de resultaten teruggekoppeld.
+Medischonderwijs.nl is bedoeld voor de distributie van *‘medical computer based training’*. Via Medisch Onderwijs werkt een groot aantal universiteiten en hogescholen samen. Vanuit CAPP kunnen modules die in Medisch Onderwijs zijn vastgelegd direct worden opgestart. Natuurlijk worden de resultaten teruggekoppeld.

--- a/source/localizable/kwaliteitspaspoort/_kwaliteitspaspoort.nl.md.erb
+++ b/source/localizable/kwaliteitspaspoort/_kwaliteitspaspoort.nl.md.erb
@@ -1,10 +1,10 @@
-Voor uw organisatie is kwaliteit van medewerkers natuurlijk belangrijk, maar soms lastig meetbaar. Samen met het Kwaliteitspaspoort(tm) van Defacto meet, borg en stuur je de kwaliteit eenvoudig, herkenbaar en aantoonbaar. Het CAPP Kwaliteitspaspoort™ geeft uw medewerkers, leidinggevenden en HR professionals inzicht in de bekwaamheden en bevoegdheden van uw team. Is het belangrijk voor u om verantwoording af te leggen aan accrediterende organisaties? Geen probleem. Wilt u effectiever gebruik maken van medewerkers, door onderbouwde compliance of een persoonlijk ontwikkelplan uitstippelen? CAPP Kwaliteitspaspoort maakt kwaliteit real time inzichtelijk waar en wanneer u het nodig heeft.
+Voor elke organisatie is de kwaliteit van medewerkers natuurlijk belangrijk maar soms lastig meetbaar. Samen met het CAPP Kwaliteitspaspoort™ van Defacto meet, borg en stuur je de kwaliteit eenvoudig, herkenbaar en aantoonbaar. Het CAPP Kwaliteitspaspoort geeft medewerkers, leidinggevenden en HR-professionals inzicht in de bekwaamheden en bevoegdheden. Is het belangrijk voor jouw organisatie om verantwoording af te leggen aan accrediterende organisaties? Geen probleem. Wil je effectiever gebruik maken van medewerkers door onderbouwde compliance of een persoonlijk ontwikkelplan uitstippelen? **Het CAPP Kwaliteitspaspoort maakt kwaliteit real time inzichtelijk waar en wanneer je het nodig hebt.**
 
-## Kwaliteitsmonitor 
+## Kwaliteitsmonitor
 
-Certificering, permanente educatie en compliance kunt u eenvoudig mogelijk maken met bestaande of door u ontwikkelde en deskundigheidsprofielen voor uw medewerkers. Zo ontstaat een integrale Kwaliteitsmonitor die een aanjager zal blijken voor de eigen verantwoordelijkheid van uw medewerker en een effectief stuurmiddel voor compliance van vakmanschap.
+Certificering, permanente educatie en compliance kun je zo eenvoudig mogelijk maken met bestaande of door jouw ontwikkelde en deskundigheidsprofielen voor medewerkers. Zo ontstaat een integrale Kwaliteitsmonitor die een aanjager zal blijken voor de eigen verantwoordelijkheid van uw medewerker en een effectief stuurmiddel voor compliance van vakmanschap.
 
-## Het Kwaliteitspaspoort in het kort
+## Het Kwaliteitspaspoort
 
 1. Uw organisatie stelt profielen vast met daarin functie- en organisatie-eisen of de beroepsprofielen in uw sector
 2. Deze vormen de basis van het Kwaliteitspaspoort van de medewerker, met alle interne en externe vereisten waaraan voldaan moet worden
@@ -13,7 +13,8 @@ Certificering, permanente educatie en compliance kunt u eenvoudig mogelijk maken
 5. HR beschikt over actuele en accurate stuurinformatie met betrekking tot aanwezige bevoegd- en bekwaamheden op elk organisatieniveau
 6. De Raad van Bestuur kan hun bestuurlijke verantwoordelijkheid aantonen richting toezichthouders en accrediterende instanties
 7. Het Kwaliteitspaspoort geeft ook de autorisaties af voor het gebruik van specialistische apparatuur, de toegangsniveaus binnen uw IT-systemen of voor een koppeling met externe kwaliteitsregisters
-
-### Eigen verantwoordelijkheid
+<br>
+   
+## Eigen verantwoordelijkheid
 
 Met CAPP kunnen medewerkers ook zelf leerinterventies, opleidingen en bijscholing zoeken, zichzelf inplannen én direct volgen via bijvoorbeeld het digitale e-learning systeem in CAPP. Hierdoor komt een stuk verantwoordelijkheid bij de medewerker zelf te liggen en biedt het een uniek instrument om de bevoegd- en bekwaamheden tijdens het jaargesprek van een medewerker te bespreken.

--- a/source/localizable/kwaliteitspaspoort/_kwaliteitspaspoort.nl.md.erb
+++ b/source/localizable/kwaliteitspaspoort/_kwaliteitspaspoort.nl.md.erb
@@ -1,13 +1,19 @@
+Voor uw organisatie is kwaliteit van medewerkers natuurlijk belangrijk, maar soms lastig meetbaar. Samen met het Kwaliteitspaspoort(tm) van Defacto meet, borg en stuur je de kwaliteit eenvoudig, herkenbaar en aantoonbaar. Het CAPP Kwaliteitspaspoort™ geeft uw medewerkers, leidinggevenden en HR professionals inzicht in de bekwaamheden en bevoegdheden van uw team. Is het belangrijk voor u om verantwoording af te leggen aan accrediterende organisaties? Geen probleem. Wilt u effectiever gebruik maken van medewerkers, door onderbouwde compliance of een persoonlijk ontwikkelplan uitstippelen? CAPP Kwaliteitspaspoort maakt kwaliteit real time inzichtelijk waar en wanneer u het nodig heeft.
+
+## Kwaliteitsmonitor 
+
+Certificering, permanente educatie en compliance kunt u eenvoudig mogelijk maken met bestaande of door u ontwikkelde en deskundigheidsprofielen voor uw medewerkers. Zo ontstaat een integrale Kwaliteitsmonitor die een aanjager zal blijken voor de eigen verantwoordelijkheid van uw medewerker en een effectief stuurmiddel voor compliance van vakmanschap.
+
 ## Het Kwaliteitspaspoort in het kort
 
-- Uw organisatie stelt profielen vast met daarin functie- en organisatie-eisen of de beroepsprofielen in uw sector.
-- Deze vormen de basis van het Kwaliteitspaspoort van de medewerker, met alle interne en externe vereisten waaraan voldaan moet worden.
-- Het individuele paspoort is een monitor voor de medewerker en helpt de medewerker zijn of haar bevoegd- en bekwaamheden op peil te houden.
-- Een leidinggevende kan op individueel èn op teamniveau tijdig problemen signaleren en vertalen naar individuele of teamontwikkelplannen.
-- HR beschikt over actuele en accurate stuurinformatie met betrekking tot aanwezige bevoegd- en bekwaamheden op elk organisatieniveau.
-- De Raad van Bestuur kan hun bestuurlijke verantwoordelijkheid aantonen richting toezichthouders en accrediterende instanties.
-- Het Kwaliteitspaspoort geeft ook de autorisaties af voor het gebruik van specialistische apparatuur, de toegangsniveaus binnen uw IT-systemen of voor een koppeling met externe kwaliteitsregisters
+1. Uw organisatie stelt profielen vast met daarin functie- en organisatie-eisen of de beroepsprofielen in uw sector
+2. Deze vormen de basis van het Kwaliteitspaspoort van de medewerker, met alle interne en externe vereisten waaraan voldaan moet worden
+3. Het individuele paspoort is een monitor voor de medewerker en helpt de medewerker zijn of haar bevoegd- en bekwaamheden op peil te houden
+4. Een leidinggevende kan op individueel èn op teamniveau tijdig problemen signaleren en vertalen naar individuele of teamontwikkelplannen
+5. HR beschikt over actuele en accurate stuurinformatie met betrekking tot aanwezige bevoegd- en bekwaamheden op elk organisatieniveau
+6. De Raad van Bestuur kan hun bestuurlijke verantwoordelijkheid aantonen richting toezichthouders en accrediterende instanties
+7. Het Kwaliteitspaspoort geeft ook de autorisaties af voor het gebruik van specialistische apparatuur, de toegangsniveaus binnen uw IT-systemen of voor een koppeling met externe kwaliteitsregisters
 
 ### Eigen verantwoordelijkheid
 
-Met CAPP kunnen medewerkers ook zelf leer- interventies, opleidingen en bijscholing opzoeken, zichzelf inplannen èn direct volgen via bijvoorbeeld het digitale E-Learning systeem binnen CAPP. Hierdoor komt een stuk verantwoordelijkheid bij de medewerker zelf te liggen en biedt het een uniek instrument om de bevoegd- en bekwaamheden tijdens het jaargesprek van een medewerker te bespreken.
+Met CAPP kunnen medewerkers ook zelf leerinterventies, opleidingen en bijscholing zoeken, zichzelf inplannen én direct volgen via bijvoorbeeld het digitale e-learning systeem in CAPP. Hierdoor komt een stuk verantwoordelijkheid bij de medewerker zelf te liggen en biedt het een uniek instrument om de bevoegd- en bekwaamheden tijdens het jaargesprek van een medewerker te bespreken.

--- a/source/localizable/learningspaces.html.erb
+++ b/source/localizable/learningspaces.html.erb
@@ -5,8 +5,8 @@ title: LearningSpaces
 <div class="hero">
   <div class="hero-inner">
     <div class="hero-copy">
-      <h1><%= image_tag "logos/learningspaces-white.png", alt: "LearningSpaces" %></h1>
-      <%= markitdown t("learningspaces.hero.text_md") %>
+      <%= image_tag "logos/learningspaces-white.png", alt: "LearningSpaces" %>
+      <h1><%= t("learningspaces.hero.text_md") %></h1>
     </div>
 
     <% if I18n.locale == :nl %>
@@ -18,7 +18,6 @@ title: LearningSpaces
        <%= link_to t("actions.visit_website"), "http://learningspaces.de", target: "_blank", class: "button white outline" %>
       <% end %>
 
-    
   </div>
 </div>
 

--- a/source/localizable/producten.html.erb
+++ b/source/localizable/producten.html.erb
@@ -7,7 +7,8 @@ title:
 
 <section class="gray">
   <div class="row">
-    <h2><%= t("products.title") %></h2>
+    <h1><%= t("products.title") %></h1>
+    <h2><%= t("products.subtitle") %></h2>
     <br>
 
     <ul class="solitions-list">

--- a/source/localizable/referenties.html.erb
+++ b/source/localizable/referenties.html.erb
@@ -7,7 +7,7 @@ title:
 
 <section class="gray">
   <div class="row">
-    <h2><%= t("references.title") %></h2>
+    <h1><%= t("references.title") %></h1>
     <br>
 
     <ul class="references-list">

--- a/source/localizable/testimonials.html.erb
+++ b/source/localizable/testimonials.html.erb
@@ -7,7 +7,7 @@ title:
 
 <section class="testimonials">
   <div class="headline">
-    <h2><%= t("testimonials.title") %></h2>
+    <h1><%= t("testimonials.title") %></h1>
   </div>
   <div class="row">
     <%= partial "testimonials" %>

--- a/source/stylesheets/_learningspaces.scss
+++ b/source/stylesheets/_learningspaces.scss
@@ -5,11 +5,19 @@
     background-image: url(../images/learningspaces-pattern.svg);
     background-position: center;
 
-
+    img { 
+      margin-bottom: 0.75em;
+    }
     h1 {
-      // @include media($large-up) {
-      //   font-size: 4em;
-      // }
+      font-size: 2em;
+      font-weight: 300;
+      line-height: 1.2em;
+      margin-bottom: 0.75em;
+    
+      @include media($small-only) {
+      font-size: 1em;
+      margin-bottom: 1.5em;
+      }
     }
   }
 

--- a/source/stylesheets/_producten.scss
+++ b/source/stylesheets/_producten.scss
@@ -1,7 +1,9 @@
 .producten_index,
 .diensten_index {
   text-align: center;
-
+  h2 { 
+    font-size: 1.5em
+  }
   .solitions-list {
     > li {
       background-color: #fff;


### PR DESCRIPTION
PR for the changes I'm working on. 

- [ ] Remove featured blog from homepage (see comments)
- [x] Only one testimonial on homepage and a button to more testimonials
- [ ] Set just one macro conversion goal per page
- [ ] add LMS to CAPP titles 
- [ ] improve content on homepage, producten, diensten, kwaliteitspaspoort, learningspaces, over ons (Rob), contact (Rob)
- [ ] new page /capp-leren (we don't know where this is placed in the site structure yet)
- [ ] new page /capp-ontwikkelen (same)
- [ ] set better URL's for capp, elearning, hosting (for ex. hosting page covers hosting AND security, but there's no mention of that in the URL)

