### PR TITLE
[READY] Remove margin on <ul> of CMT page

### DIFF
--- a/source/stylesheets/_convenant.scss
+++ b/source/stylesheets/_convenant.scss
@@ -6,10 +6,6 @@
     max-width: 70%;
   }
 
-  ul {
-    margin-left: 1em;
-  }
-
   .hero {
     @include radial-gradient(circle at 50%,
       $blue 33%,


### PR DESCRIPTION
The margin on the `ul` is no longer needed and influenced the ul's in the footer