### PR TITLE
[READY] don't block redirected pages from robots

### DIFF
--- a/source/robots.txt.erb
+++ b/source/robots.txt.erb
@@ -10,7 +10,3 @@ User-agent: *
 Disallow: <%= page.url %>
 <% end -%>
 Disallow: /workshop-convenant-mt/
-Disallow: /capp/
-Disallow: /elearning/
-Disallow: /elearning-starterkit/
-Disallow: /hosting/


### PR DESCRIPTION
Blocking the redirected pages was a mistake, we do want robots to find the redirected url's, even if the redirects occur on the client side. 