### PR TITLE
[WIP] fix broken link on cmt page

### DIFF
--- a/source/localizable/_header.erb
+++ b/source/localizable/_header.erb
@@ -18,7 +18,8 @@
         <% end %>
         <li><%= nav_link_to t("header.contact"), "/contact.html" %></li>
         <li class="flags">
-          <%= country_flags %>
+          <%= country_flags unless current_page.url == "/convenant-medische-technologie/" %>
+          <%= link_to image_tag("flags/de.gif", alt: "Deutsch"), "http://www.defactolearning.de", target: "_blank" if current_page.url == "/convenant-medische-technologie/" %>
           <%= link_to image_tag("flags/en.gif", alt: "English"), "http://en.defacto.nl", target: "_blank" %>
         </li>
       </ul>


### PR DESCRIPTION
This is ready for review. 

On [this page](http://www.defacto.nl/convenant-medische-technologie/) the German flag points to a non existing page, so I pointed the flag to the German homepage. 

Maybe there could be a more sustainable way to do this? 
