### PR TITLE
[READY] use hreflangs for locales

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -261,6 +261,18 @@ helpers do
     html
   end
 
+  # Href langs
+  def href_langs
+    html = ""
+      langs.each do |lang|
+      locale_root_path = current_page.locale_root_path
+      url = locale_root_path ? locale_root_path : "/"
+      url = full_url locale_url_for(url, locale: lang)
+      html << tag(:link, rel: "alternate", href: url, hreflang: "#{lang}-#{lang}") + "\n    "
+    end
+    html
+  end
+
   # String to markdown
   def markitdown(string)
     # Kramdown::Document.new(string, config[:markdown]).to_html

--- a/config.rb
+++ b/config.rb
@@ -264,7 +264,7 @@ helpers do
   # Href langs
   def href_langs
     html = ""
-      langs.each do |lang|
+    langs.each do |lang|
       locale_root_path = current_page.locale_root_path
       url = locale_root_path ? locale_root_path : "/"
       url = full_url locale_url_for(url, locale: lang)

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -25,6 +25,8 @@
     <%= tag(:meta, name: "robots", content: current_page.data.robots) if current_page.data.robots -%>
     <%= tag(:link, rel: "canonical", href: current_page.data.canonical_url) if current_page.data.canonical_url -%>
 
+    <%= href_langs %>
+
     <meta property="og:site_name" content="Defacto - Developing People">
     <meta property="og:title" content="<%= page_title(current_page, false) %>">
     <meta property="og:url" content="<%= full_url(current_page.url) %>">


### PR DESCRIPTION
Even last weekend we saw German users land on the NL TLD, so we need to make clear for search engines which version of the Defacto site is which. With a bit of help from @sn3p we made a helper to set hreflangs in each version of the site. 

Some more info on this: 

https://support.google.com/webmasters/answer/189077?hl=nl 
https://moz.com/learn/seo/hreflang-tag

