### PR TITLE
[READY] Prevent deployment when build fails

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -22,9 +22,9 @@ end
 namespace :build do
   def build(env)
     puts "*"*50
-    puts "* Building #{env.upcase}"
+    puts "* Building #{env.upcase} ..."
     puts "*"*50
-    system "LOCALE=#{env} bundle exec middleman build --clean"
+    system "LOCALE=#{env} bundle exec middleman build --clean" or exit(1)
   end
 
   desc "Build NL"
@@ -42,9 +42,17 @@ end
 ## Deploy
 namespace :deploy do
   def deploy(env)
-    Rake::Task["build:#{env}"].invoke
+    begin
+      Rake::Task["build:#{env}"].invoke
+    rescue SystemExit => e
+      puts "*"*50
+      puts "* Build failed, skipping deployment (locale #{env.upcase})"
+      puts "*"*50
+      exit(e.status)
+    end
+
     puts "*"*50
-    puts "* Deploying #{env.upcase}"
+    puts "* Build successful, Deploying #{env.upcase} ... "
     puts "*"*50
     system "LOCALE=#{env} bundle exec middleman deploy"
   end


### PR DESCRIPTION
Fixing https://github.com/DefactoSoftware/website/issues/277


The `rake deploy` task now exits when the the build fails.

<img width="742" alt="screen shot 2016-07-28 at 11 59 45" src="https://cloud.githubusercontent.com/assets/935529/17209868/a999d39c-54bf-11e6-9c8c-5bbd1d254404.png">

<img width="655" alt="screen shot 2016-07-28 at 12 00 38" src="https://cloud.githubusercontent.com/assets/935529/17209878/b2c45370-54bf-11e6-8e0e-4ade5561f491.png">

This differs from the LearningSpaces landing page we're using a [`deploy` bash script](https://github.com/DefactoSoftware/LearningSpaces-Landing/blob/master/deploy).