### PR TITLE
[READY] update mobile toggle view

### DIFF
--- a/source/stylesheets/_header.scss
+++ b/source/stylesheets/_header.scss
@@ -1,5 +1,5 @@
 #header {
-  $desktop-mode: $medium-up;
+  $desktop-mode: $large-up;
 
   @include clearfix;
   background-color: #fff;


### PR DESCRIPTION
When `$desktop-mode: $large-up;` (860px) hide the toggle instead of `medium-up `(640px). 

### Now:
![screenshot-oud](https://cloud.githubusercontent.com/assets/16101007/19277447/073e63fa-8fda-11e6-9ba3-f52144e5ea1d.png)

### Fixed:
![screenshot-nieuw](https://cloud.githubusercontent.com/assets/16101007/19277458/10f5b060-8fda-11e6-9280-cde5e081d905.png)

