### PR TITLE
[READY] add locale check to hreflangs in main layout

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -25,7 +25,7 @@
     <%= tag(:meta, name: "robots", content: current_page.data.robots) if current_page.data.robots -%>
     <%= tag(:link, rel: "canonical", href: current_page.data.canonical_url) if current_page.data.canonical_url -%>
 
-    <%= href_langs unless is_blog_article? || current_page.url == "/convenant-medische-technologie/" -%>
+    <%= href_langs unless is_blog_article? || current_page.data.unique_for_locale == true -%>
 
     <meta property="og:site_name" content="Defacto - Developing People">
     <meta property="og:title" content="<%= page_title(current_page, false) %> - Defacto">


### PR DESCRIPTION
`href_langs` tells (search engine) robots which version of a page is correct for a certain language. 

If unique_for_locale is true, do not return href_langs, or else it points to a non existing (404) page! 

```
<link rel="alternate" href="http://www.defacto.nl/learningspaces/" hreflang="nl-nl" />
<link rel="alternate" href="http://www.defactolearning.de/learningspaces/" hreflang="de-de" />
```
    
    