### PR TITLE
[READY] add unique for locale to capp lms page

### DIFF
--- a/source/localizable/capp-lms.nl.erb
+++ b/source/localizable/capp-lms.nl.erb
@@ -3,6 +3,7 @@ title:
   nl: Opleiden, Leren en Ontwikkelen met CAPP LMS
 description:
   nl: Maak medewerkers aantoonbaar vakbevoegd en vakbekwaam met CAPP LMS.
+unique_for_locale: true
 ---
 
 <div class="hero">


### PR DESCRIPTION
defacto.nl/capp-lms doesn't exist on defactolearning.de,  
there it's /capp-bilden and /capp-entwickeln.  

-> Point it to the homepage
