### PR TITLE
[READY] add prefix to blog author

### DIFF
--- a/source/blog/_featured.erb
+++ b/source/blog/_featured.erb
@@ -10,7 +10,7 @@ featured = blog.local_articles.find { |item| item.metadata[:page]["featured"] re
 
 if featured
   author = blog_author(featured)
-  author_name = author ? "#{author.firstname} #{author.lastname}" : featured.data.author
+  author_name = author ? "#{author.firstname} #{author.prefix} #{author.lastname}" : featured.data.author
 %>
 
   <div class="row blog blog-featured">

--- a/source/blog/feed.xml.builder
+++ b/source/blog/feed.xml.builder
@@ -19,7 +19,7 @@ xml.feed "xmlns" => "http://www.w3.org/2005/Atom" do
       # Try to get author for team.yml
       if article.data.author
         author = blog_author(article)
-        author = author ? "#{author.firstname} #{author.lastname}" : article.data.author
+        author = author ? "#{author.firstname} #{author.prefix} #{author.lastname}" : article.data.author
         xml.author { xml.name author }
       end
 

--- a/source/blog/index.html.erb
+++ b/source/blog/index.html.erb
@@ -27,7 +27,7 @@ pageable: true
               <div class="post-meta">
                 <%
                 author = blog_author(article)
-                author_name = author ? "#{author.firstname} #{author.lastname}" : article.data.author
+                author_name = author ? "#{author.firstname} #{author.prefix} #{author.lastname}" : article.data.author
                 %>
                 <span class="author-name"><%= author_name %></span>
                 <time datetime="<%= article.date.strftime('%F') %>"><%= I18n.l(article.date, format: "%e %B %Y", locale: I18n.locale.to_s) %></time>

--- a/source/layouts/blog_post_layout.erb
+++ b/source/layouts/blog_post_layout.erb
@@ -1,7 +1,7 @@
 <% wrap_layout :layout do %>
   <%
   author = blog_author(current_article)
-  author_name = author ? "#{author.firstname} #{author.lastname}" : current_article.data.author
+  author_name = author ? "#{author.firstname} #{author.prefix} #{author.lastname}" : current_article.data.author
   %>
 
   <article>


### PR DESCRIPTION
This was added recently to team.yml to make a better alphabetic order on the team page, but was not added at blog posts and the feed.xml

Here's when I made the add the last featured  to Iwanna **de** Jonge
![blog-author](https://cloud.githubusercontent.com/assets/16101007/20627607/6ea0bd80-b321-11e6-8365-ee08c18a13a1.png)
