### PR TITLE
[READY] ignore featured image folder for asset hash

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -131,7 +131,7 @@ configure :build do
   activate :minify_javascript
 
   # Enable cache buster
-  activate :asset_hash #, ignore: [%r{^blog}]
+  activate :asset_hash, ignore: "images/blog/featured"
 
   # Use relative URLs
   # activate :relative_assets


### PR DESCRIPTION
Hm, featured_image gets a hash on build. Let's ignore the folder with these images on build?

## Before
![before](https://cloud.githubusercontent.com/assets/16101007/20924283/0ea057ae-bbb1-11e6-90a4-6c73a5475b49.png)

## After 
![screen-shot-2016-12-06-at-12 16 47](https://cloud.githubusercontent.com/assets/16101007/20923678/f9e597d2-bbad-11e6-8254-9481bfc9fcf8.png)
