### PR TITLE
[READY] Change google conversion frame setting

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -68,6 +68,7 @@
       var google_conversion_id = 1008438803;
       var google_custom_params = window.google_tag_params;
       var google_remarketing_only = true;
+      var google_conversion_format = 3;
       /* ]]> */
     </script>
     <script type="text/javascript" src="//www.googleadservices.com/pagead/conversion.js"></script>

--- a/source/stylesheets/main.scss
+++ b/source/stylesheets/main.scss
@@ -37,14 +37,3 @@
 .fluid-width-video-wrapper {
   margin-bottom: 1em;
 }
-
-// Hide Google Conversion iframe
-iframe[name="google_conversion_frame"] {
-  display: none !important;
-  float: left;
-  font-size: 0 !important;
-  height: 0 !important;
-  line-height: 0 !important;
-  margin-top: -13px;
-  width: 0 !important;
-}


### PR DESCRIPTION
We used this before to hide the Google conversion frame in legacy IE browser. 

```
// Hide Google Conversion iframe
iframe[name="google_conversion_frame"] {
  display: none !important;
  float: left;
  font-size: 0 !important;
  height: 0 !important;
  line-height: 0 !important;
  margin-top: -13px;
  width: 0 !important;
}
```

But it can be done with a setting. 

`var google_conversion_format = 3;`

http://stackoverflow.com/questions/13162495/whats-difference-values1-2-3-of-google-conversion-format 

## Without settings

With no var google conversion format = 3 and no CSS, there's a 13 px white stroke below the page:

![screenshot 2016-12-06 15 00 04](https://cloud.githubusercontent.com/assets/16101007/20928269/5371142c-bbc5-11e6-86fe-3a1555b07e26.png)

## With setting

With conversion format = 3 the 13 px are gone: 

![screenshot 2016-12-06 15 00 32](https://cloud.githubusercontent.com/assets/16101007/20928279/612fc392-bbc5-11e6-9e7c-846d8301561e.png)

part of #347 cleansing
