### PR TITLE
[READY] remove popup from pages with other main goals

### DIFF
--- a/source/localizable/360-feedback.html.erb
+++ b/source/localizable/360-feedback.html.erb
@@ -3,6 +3,7 @@ title: 360° Feedback
 description:
   nl: Moeiteloos evaluaties uitvoeren in een gebruiksvriendelijke cloudservice. Kijk in de spiegel met 360° Feedback.
   de: Das Tool für eine effiziente Personalentwicklung. 360° Feedback schafft Transparenz zwischen dem Vorgesetzten und seinen Mitarbeitern.
+popup: false
 ---
 
 <div class="hero">

--- a/source/localizable/capp-bilden.de.erb
+++ b/source/localizable/capp-bilden.de.erb
@@ -4,6 +4,7 @@ title:
 description:
   de: CAPP Bilden ist eine Software für das Bildungsmanagement und E-Learning im Gesundheitswesen.
 unique_for_locale: true
+popup: false
 ---
 
 <div class="hero">

--- a/source/localizable/capp-entwickeln.de.erb
+++ b/source/localizable/capp-entwickeln.de.erb
@@ -4,6 +4,7 @@ title:
 description:
   de: CAPP Entwickeln ist eine Software für das Kompetenzmanagement und die Personalentwicklung.
 unique_for_locale: true
+popup: false
 ---
 
 <div class="hero">

--- a/source/localizable/capp-lms.nl.erb
+++ b/source/localizable/capp-lms.nl.erb
@@ -4,6 +4,7 @@ title:
 description:
   nl: Maak medewerkers aantoonbaar vakbevoegd en vakbekwaam met CAPP LMS.
 unique_for_locale: true
+popup: false
 ---
 
 <div class="hero">

--- a/source/localizable/contact.html.erb
+++ b/source/localizable/contact.html.erb
@@ -6,6 +6,7 @@ title:
 description:
   nl: Neem contact op met Defacto via het contactformulier of bel 050 – 3144 832.
   de: Kontakt Defacto über das Kontaktformular oder rufen Sie +49 (0)40 306988472.
+popup: false
 ---
 
 <section class="gray">

--- a/source/localizable/convenant-medische-technologie.nl.erb
+++ b/source/localizable/convenant-medische-technologie.nl.erb
@@ -2,6 +2,7 @@
 title: In 3 stappen geen zorgen meer rondom het Convenant Medische Technologie
 description: Hoe gaat uw organisatie de kwaliteitsregistratie organiseren? Met het CAPP Kwaliteitspaspoort ontzorgen wij zorginstellingen.
 unique_for_locale: true
+popup: false
 ---
 
 <% permalink_url = full_url(current_page.url) %>

--- a/source/localizable/e-learning-starterkit.html.erb
+++ b/source/localizable/e-learning-starterkit.html.erb
@@ -5,6 +5,7 @@ title:
 description:
   nl: Maak je eigen content met de E-Learning Starterkit van Defacto. Zo bespaar je geld en sluit content beter aan.
   de: Erstellen Sie Ihre eigenen Module mit dem E-Learning Starterkit. Sparen Sie Geld und passen Sie Ihre Inhalte besser an.
+popup: false
 ---
 
 <div class="hero">

--- a/source/localizable/e-learning.html.erb
+++ b/source/localizable/e-learning.html.erb
@@ -3,6 +3,7 @@ title: E-Learning
 description:
   nl: Met Defacto als ervaren en technisch onderlegde partner wordt e-learning in jouw organisatie een succes.
   de: Mit Defacto als erfahrenem und technisch geschultem Partner wird E-Learning in Ihrer Organisation zum Erfolg.
+popup: false
 ---
 
 <section class="gray">

--- a/source/localizable/kwaliteitspaspoort.html.erb
+++ b/source/localizable/kwaliteitspaspoort.html.erb
@@ -6,6 +6,7 @@ title:
 description:
   nl: Elke medewerker aantoonbaar bekwaam met het CAPP Kwaliteitspaspoort van Defacto. Maak kwaliteit transparant.
   de: Compliance mit dem CAPP Qualitätspass von Defacto.
+popup: false
 ---
 
 <div class="hero">

--- a/source/localizable/learningspaces.html.erb
+++ b/source/localizable/learningspaces.html.erb
@@ -3,6 +3,7 @@ title: LearningSpaces
 description:
   nl: Handleidingen. Werkwijzen. Tips en trucs. In LearningSpaces kan je hele team specialismen met elkaar delen.
   de: LearningSpaces ist eine spielerische und einfach zu bedienende Plattform die informelles Lernen und den Wissensaustausch stimuliert.
+popup: false
 ---
 
 <div class="hero">


### PR DESCRIPTION
Don't show the e-book pop-up on pages with other main conversion goals. 

In my opinion main conversion goals are: 

**- CAPP LMS (pages):** download productsheet
**- Kwaliteitspaspoort:** fill in the form in the bottom
**- LearningSpaces:** click through to register or to LS-landing
**- 360-feedback:** click through to register
**- Contact:** fill in the form
**- Convenant MT:** fill in the form in the bottom
**- E-Learning Starterkit:** fill in the form or download e-book in the bottom 
**- E-Learning:** fill in the form in the bottom

Fixes #388 