### PR TITLE
Autoprefixer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,13 +8,13 @@ gem "middleman-blog", "~> 3.5.3"
 gem "middleman-deploy", "~> 1.0"
 # gem "middleman-livereload", "~> 3.4.2"
 gem "middleman-syntax"
+gem "middleman-autoprefixer"
 # gem "redcarpet"
 gem "nokogiri"
 gem "builder" # For feed.xml.builder
 gem "rake"
 
-# Bitters, Bourbon, Neat
-# gem "bitters"
+# Bourbon, Neat
 gem "bourbon"
 gem "neat"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,8 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.3.8)
+    autoprefixer-rails (6.6.1)
+      execjs
     bourbon (4.2.4)
       sass (~> 3.4)
       thor (~> 0.19)
@@ -61,6 +63,9 @@ GEM
       middleman-sprockets (>= 3.1.2)
       sass (>= 3.4.0, < 4.0)
       uglifier (~> 2.5)
+    middleman-autoprefixer (2.7.1)
+      autoprefixer-rails (>= 6.5.2, < 7.0.0)
+      middleman-core (>= 3.3.3)
     middleman-blog (3.5.3)
       addressable (~> 2.3.5)
       middleman-core (~> 3.2)
@@ -153,6 +158,7 @@ DEPENDENCIES
   bourbon
   builder
   middleman (~> 3.4.0)
+  middleman-autoprefixer
   middleman-blog (~> 3.5.3)
   middleman-deploy (~> 1.0)
   middleman-syntax
@@ -165,4 +171,4 @@ DEPENDENCIES
   rake
 
 BUNDLED WITH
-   1.12.5
+   1.13.6

--- a/config.rb
+++ b/config.rb
@@ -104,6 +104,9 @@ page "blog/index.html", layout: :blog_layout
 page "blog/feed.xml", layout: false
 
 activate :directory_indexes
+activate :autoprefixer do |config|
+  config.browsers = ['last 3 versions', 'Explorer >= 9']
+end
 
 set :relative_links, true
 set :css_dir, "stylesheets"

--- a/config.rb
+++ b/config.rb
@@ -105,7 +105,7 @@ page "blog/feed.xml", layout: false
 
 activate :directory_indexes
 activate :autoprefixer do |config|
-  config.browsers = ['last 3 versions', 'Explorer >= 9']
+  config.browsers = ["last 3 versions", "Explorer >= 9"]
 end
 
 set :relative_links, true

--- a/source/stylesheets/_bedankt.scss
+++ b/source/stylesheets/_bedankt.scss
@@ -1,6 +1,7 @@
 body.bedankt {
   .gray {
-    @include radial-gradient(#fbfbfb, #dfdfdf, $fallback: #fbfbfb);
+    background-color: #fbfbfb;
+    background-image: radial-gradient(#fbfbfb, #dfdfdf);
   }
 
   .header-icon {

--- a/source/stylesheets/_blog.scss
+++ b/source/stylesheets/_blog.scss
@@ -3,9 +3,9 @@
   $blog-link-color: darken($blue, 10);
 
   a {
-    @include transition(color 0.1s linear);
     color: $blog-link-color;
     text-decoration: none;
+    transition: color 0.1s linear;
 
     &:active,
     &:focus,
@@ -64,11 +64,11 @@
 
   .post-body {
     img {
-      @include transform(translateX(-50%));
       display: block;
       left: 50%;
       padding: 0.6em 0;
       position: relative;
+      transform: translateX(-50%);
     }
   }
 
@@ -91,7 +91,8 @@
 .blog_index {
   .blog-header {
     $background-color: #fcfcfc;
-    @include linear-gradient(darken($background-color, 2), $background-color 120px, $fallback: $background-color);
+    background-color: $background-color;
+    background-image: radial-gradient(darken($background-color, 2), $background-color 120px);
     padding: 0;
 
     h1 {
@@ -178,7 +179,8 @@
 
       .post-header {
         $background-color: #fcfcfc;
-        @include linear-gradient(darken($background-color, 2), $background-color 120px, $fallback: $background-color);
+        background-color: $background-color;
+        background-image: radial-gradient(darken($background-color, 2), $background-color 120px);
 
         h1 {
           margin-bottom: 0.5em;

--- a/source/stylesheets/_capp.scss
+++ b/source/stylesheets/_capp.scss
@@ -2,14 +2,14 @@ body.capp-lms,
 body.capp-bilden,
 body.capp-entwickeln {
   .hero {
-    @include radial-gradient(circle at 50%,
+    background-attachment: scroll;
+    background-color: $blue-alt;
+    background-image: radial-gradient(
+      circle at 50%,
       $blue 33%,
       rgba($blue, 0.5) 33%,
       rgba($blue, 0.5) 66%,
-      $blue-alt 66%,
-      $fallback: $blue-alt);
-
-    background-attachment: scroll;
+      $blue-alt 66%);
 
     h1 {
       font-family: 'Montserrat', $base-font-family;

--- a/source/stylesheets/_clients.scss
+++ b/source/stylesheets/_clients.scss
@@ -1,19 +1,18 @@
 .clients {
   $background-color: #fcfcfc;
 
+  background-color: $background-color;
+  background-image: linear-gradient(darken($background-color, 2), $background-color 120px);
+  text-align: center;
+
   h2 {
     font-size: 1.8em;
   }
 
-  @include linear-gradient(darken($background-color, 2), $background-color 120px, $fallback: $background-color);
-  text-align: center;
-
-  .logos {
-    img {
-      margin: 1em 2em;
-      max-height: 50px;
-      max-width: 180px;
-      opacity: 0.5;
-    }
+  .logos img {
+    margin: 1em 2em;
+    max-height: 50px;
+    max-width: 180px;
+    opacity: 0.5;
   }
 }

--- a/source/stylesheets/_convenant.scss
+++ b/source/stylesheets/_convenant.scss
@@ -1,20 +1,13 @@
 .convenant-medische-technologie {
-
-  h1 {
-    font-size: 1.8em;
-    margin: 0 auto 2em;
-    max-width: 70%;
-  }
-
   .hero {
-    @include radial-gradient(circle at 50%,
+    background-attachment: scroll;
+    background-color: $blue-alt;
+    background-image: radial-gradient(
+      circle at 50%,
       $blue 33%,
       rgba($blue, 0.5) 33%,
       rgba($blue, 0.5) 66%,
-      $blue-alt 66%,
-      $fallback: $blue-alt);
-
-    background-attachment: scroll;
+      $blue-alt 66%);
   }
 
   .hero-inner {
@@ -23,6 +16,12 @@
 
   .hero-copy {
     font-size: 1em;
+  }
+
+  h1 {
+    font-size: 1.8em;
+    margin: 0 auto 2em;
+    max-width: 70%;
   }
 
   h2 {

--- a/source/stylesheets/_conversion.scss
+++ b/source/stylesheets/_conversion.scss
@@ -1,14 +1,14 @@
 body.demo-aanvragen,
 body.productsheet-downloaden {
   .hero {
-    @include radial-gradient(circle at 50%,
+    background-attachment: scroll;
+    background-color: $blue-alt;
+    background-image: radial-gradient(
+      circle at 50%,
       $blue 33%,
       rgba($blue, 0.5) 33%,
       rgba($blue, 0.5) 66%,
-      $blue-alt 66%,
-      $fallback: $blue-alt);
-
-    background-attachment: scroll;
+      $blue-alt 66%);
 
     h1 {
       font-family: 'Montserrat', $base-font-family;

--- a/source/stylesheets/_error.scss
+++ b/source/stylesheets/_error.scss
@@ -1,6 +1,7 @@
 body.x404 {
   .gray {
-    @include radial-gradient(#fbfbfb, #dfdfdf, $fallback: #fbfbfb);
+    background-color: #fbfbfb;
+    background-image: radial-gradient(#fbfbfb, #dfdfdf);
   }
 
   .header-icon {

--- a/source/stylesheets/_feature_list.scss
+++ b/source/stylesheets/_feature_list.scss
@@ -108,8 +108,8 @@
 
 .feature-keywords {
   $background-color: #fcfcfc;
-
-  @include linear-gradient(darken($background-color, 2), $background-color 120px, $fallback: $background-color);
+  background-color: $background-color;
+  background-image: radial-gradient(darken($background-color, 2), $background-color 120px);
   display: none;
   padding-bottom: 2em;
 


### PR DESCRIPTION
Installed Autoprefixer with the following browser support:

```rb
config.browsers = ["last 3 versions", "Explorer >= 9"]
```

This means all `@include` vendor prefix mixins can be removed, and replaces with standard css properties. I've already started doing this but the rest can be done later.